### PR TITLE
Fix autofilter for LibreOffice

### DIFF
--- a/src/FastExcelWriter/Sheet.php
+++ b/src/FastExcelWriter/Sheet.php
@@ -36,6 +36,7 @@ class Sheet
     public $freezeRows      = 0;
     public $freezeColumns   = 0;
     public $autoFilter      = 0;
+    public $absoluteAutoFilter = '';
 
     // zero based
     public $colWidths       = [];
@@ -293,6 +294,7 @@ class Sheet
                 $this->autoFilter = Excel::cellAddress($row, $col);
             }
         }
+        $this->absoluteAutoFilter = Excel::cellAddress($row, $col, true);
         return $this;
     }
 

--- a/src/FastExcelWriter/Writer.php
+++ b/src/FastExcelWriter/Writer.php
@@ -867,13 +867,21 @@ class Writer
         $workbookXml .= '<fileVersion appName="Calc"/><workbookPr backupFile="false" showObjects="all" date1904="false"/><workbookProtection/>';
         $workbookXml .= '<bookViews><workbookView activeTab="0" firstSheet="0" showHorizontalScroll="true" showSheetTabs="true" showVerticalScroll="true" tabRatio="212" windowHeight="8192" windowWidth="16384" xWindow="0" yWindow="0"/></bookViews>';
         $workbookXml .= '<sheets>';
+        $definedNames = '';
         foreach ($sheets as $sheet) {
             $sheetName = self::sanitizeSheetName($sheet->sheetName);
             $workbookXml .= '<sheet name="' . self::xmlSpecialChars($sheetName) . '" sheetId="' . ($i + 1) . '" state="visible" r:id="rId' . ($i + 2) . '"/>';
+            if ($sheet->absoluteAutoFilter) {
+                $filterRange = $sheet->absoluteAutoFilter . ':' . Excel::cellAddress($sheet->rowCount, $sheet->colCount, true);
+                $definedNames .= '<definedName name="_xlnm._FilterDatabase" localSheetId="' . $i . '" hidden="1">\'' . $sheetName . '\'!' . $filterRange . '</definedName>';
+            }
             $i++;
         }
         $workbookXml .= '</sheets>';
         $workbookXml .= '<definedNames>';
+        if ($definedNames) {
+            $workbookXml .= $definedNames;
+        }
         $workbookXml .= '</definedNames>';
         $workbookXml .= '<calcPr iterateCount="100" refMode="A1" iterate="false" iterateDelta="0.001"/></workbook>';
 


### PR DESCRIPTION
Fix for the issue inherited (I guess) from PHP_XLSXWriter:
https://github.com/mk-j/PHP_XLSXWriter/issues/61
The issue is with LibreOffice (haven't tried with OpenOffice, but I guess it would be the same). If you set Auto Filter it works in MS Excel but when the file is opened with Libre filters are not there. I've seen it working in PhpSpreadsheet, so I knew it must be possible. ;)

Following the original solution:
https://github.com/cgaudelet/PHP_XLSXWriter/pull/1/commits/351c1ddb06312467e7af54b5963e8ffa7152fa9c
I added few lines for creating "definedName" entries in workbook.xml (also fixing one small thing that was omitted back then).
Seems to be working fine in both environments now.