### PR TITLE
Add Row & Col ID getters to Sheet

### DIFF
--- a/src/FastExcelWriter/Sheet.php
+++ b/src/FastExcelWriter/Sheet.php
@@ -302,6 +302,22 @@ class Sheet implements InterfaceSheetWriter
     }
 
     /**
+    * @return int
+    */
+    public function getCurrentRowId(): int
+    {
+        return $this->currentRowIdx;
+    }
+
+    /**
+    * @return int
+    */
+    public function getCurrentColId(): int
+    {
+        return $this->currentColIdx;
+    }
+    
+    /**
      * @return array
      */
     public function getExternalLinks(): array


### PR DESCRIPTION
Hi, great package.

The Sheet uses `currentRowIdx` and `currentColIdx` to store the current position, however both of these are protected (fairly so).
There is, however, no way to get these values currently so you have to maintain your own counter alongside if you want to keep track of what row you're on.

This simply adds two getter functions, `getCurrentRowId` and `getCurrentColId`.