### PR TITLE
Show correct error when unable to create a zip

### DIFF
--- a/src/FastExcelWriter/Writer/Writer.php
+++ b/src/FastExcelWriter/Writer/Writer.php
@@ -467,8 +467,9 @@ class Writer
         }
 
         $this->zip = new \ZipArchive();
-        if (!$this->zip->open($fileName, \ZIPARCHIVE::CREATE)) {
-            ExceptionFile::throwNew('Unable to create zip "%s"', $fileName);
+        $result = $this->zip->open($fileName, \ZIPARCHIVE::CREATE);
+        if ($result !== TRUE) {
+            ExceptionFile::throwNew('Unable to create zip "%s". Error code "%s"', $fileName, $result);
         }
 
         // add sheets
@@ -553,8 +554,9 @@ class Writer
         }
 
         $this->zip = new \ZipArchive();
-        if (!$this->zip->open($outputFile)) {
-            ExceptionFile::throwNew('Unable to open zip "%s"', $outputFile);
+        $result = $this->zip->open($outputFile, \ZIPARCHIVE::CREATE);
+        if ($result !== TRUE) {
+            ExceptionFile::throwNew('Unable to open zip "%s". Error code "%s"', $outputFile, $result);
         }
         $entryList = [];
         for ($i = 0; $i < $this->zip->numFiles; $i++) {


### PR DESCRIPTION
When [`saveToFile`](https://github.com/aVadim483/fast-excel-writer/blob/master/src/FastExcelWriter/Writer/Writer.php#L423) method is called with an invalid name or insufficient permissions 

Current exception is:

`Could not write entry "[Content_Types].xml" to zip`
> This error occurs because when trying to execute `writeEntryToZip` the zip wasn't created properly

The correct exception has to be

`Unable to create zip "pathname_with_incorrect_name_or_permission.xlsx". Error code "XX"`

> Where XX corresponds to the [return values section of ZipArchive according to the official docs](https://www.php.net/manual/en/ziparchive.open.php)