### PR TITLE
fixed php 8.4 warning 

### DIFF
--- a/src/FastExcelWriter/Area.php
+++ b/src/FastExcelWriter/Area.php
@@ -185,7 +185,7 @@ class Area
      *
      * @return bool
      */
-    protected function _validateAddressRange(&$cellAddress, array &$index = null, array &$offset = null): bool
+    protected function _validateAddressRange(&$cellAddress, ?array &$index = null, ?array &$offset = null): bool
     {
         if ($cellAddress) {
             if (is_string($cellAddress)) {
@@ -305,7 +305,7 @@ class Area
      *
      * @return $this
      */
-    public function setFormula($cellAddress, $value, array $style = null): Area
+    public function setFormula($cellAddress, $value, ?array $style = null): Area
     {
         if ($this->_validateAddressRange($cellAddress)) {
             $this->sheet->setFormula($cellAddress, $value, $style);

--- a/src/FastExcelWriter/Charts/Chart.php
+++ b/src/FastExcelWriter/Charts/Chart.php
@@ -228,9 +228,9 @@ class Chart
      * @param GridLines|null $majorGridlines
      * @param GridLines|null $minorGridlines
      */
-    public function __construct($title, $plotArea, Legend $legend = null, ?bool $plotVisibleOnly = true, ?string $displayBlanksAs = '0',
-                                $xAxisLabel = null, $yAxisLabel = null, Axis $xAxis = null, Axis $yAxis = null, GridLines $majorGridlines = null,
-                                GridLines $minorGridlines = null)
+    public function __construct($title, $plotArea, ?Legend $legend = null, ?bool $plotVisibleOnly = true, ?string $displayBlanksAs = '0',
+                                $xAxisLabel = null, $yAxisLabel = null, ?Axis $xAxis = null, ?Axis $yAxis = null, ?GridLines $majorGridlines = null,
+                                ?GridLines $minorGridlines = null)
     {
         $this->setTitle($title);
         $this->legend = $legend;
@@ -872,7 +872,7 @@ class Chart
      *
      * @return $this
      */
-    public function setTopLeftPosition(string $cell, int $xOffset = null, int $yOffset = null): Chart
+    public function setTopLeftPosition(string $cell, ?int $xOffset = null, ?int $yOffset = null): Chart
     {
         $this->topLeftCellRef = $cell;
         if (!is_null($xOffset)) {

--- a/src/FastExcelWriter/Charts/DataSeries.php
+++ b/src/FastExcelWriter/Charts/DataSeries.php
@@ -305,7 +305,7 @@ class DataSeries
      *
      * @return DataSeries
      */
-    public function setPlotGrouping(string $groupingType = null): DataSeries
+    public function setPlotGrouping(?string $groupingType = null): DataSeries
     {
         $this->plotGrouping = $groupingType;
 
@@ -339,7 +339,7 @@ class DataSeries
      *
      * @return DataSeries
      */
-    public function setPlotChartDirection(string $plotChartDirection = null): DataSeries
+    public function setPlotChartDirection(?string $plotChartDirection = null): DataSeries
     {
         $this->plotChartDirection = $plotChartDirection;
 

--- a/src/FastExcelWriter/Charts/Legend.php
+++ b/src/FastExcelWriter/Charts/Legend.php
@@ -57,7 +57,7 @@ class Legend
     /**
      *    Create a new Legend
      */
-    public function __construct($position = self::POSITION_RIGHT, Layout $layout = null, $overlay = false)
+    public function __construct($position = self::POSITION_RIGHT, ?Layout $layout = null, $overlay = false)
     {
         $this->setPosition($position);
         $this->layout = $layout;

--- a/src/FastExcelWriter/Charts/PlotArea.php
+++ b/src/FastExcelWriter/Charts/PlotArea.php
@@ -35,7 +35,7 @@ class PlotArea
     /**
      * Create a new PlotArea
      */
-    public function __construct($dataSeries = null, Layout $layout = null)
+    public function __construct($dataSeries = null, ?Layout $layout = null)
     {
         $this->defaultColors = ['5b9bd5', 'ed7d31', 'a5a5a5', 'ffc000', '4472c4', '70ad47'];
         $this->layout = $layout;

--- a/src/FastExcelWriter/Charts/Title.php
+++ b/src/FastExcelWriter/Charts/Title.php
@@ -26,7 +26,7 @@ class Title
     /**
      * Create a new Title
      */
-    public function __construct(?string $caption = null, Layout $layout = null)
+    public function __construct(?string $caption = null, ?Layout $layout = null)
     {
         $this->caption = $caption;
         $this->layout = $layout;

--- a/src/FastExcelWriter/Excel.php
+++ b/src/FastExcelWriter/Excel.php
@@ -435,7 +435,7 @@ class Excel implements InterfaceBookWriter
      *
      * @return $this
      */
-    public function setLocale(string $locale, string $dir = null): Excel
+    public function setLocale(string $locale, ?string $dir = null): Excel
     {
         $localeSettings = [];
         // default settings
@@ -1025,7 +1025,7 @@ class Excel implements InterfaceBookWriter
      * cellAddress(43, 27, true) => '$AA$43'
      * cellAddress(43, 27, false, true) => 'AA$43'
      */
-    public static function cellAddress(int $rowNumber, int $colNumber, ?bool $absolute = false, bool $absoluteRow = null): string
+    public static function cellAddress(int $rowNumber, int $colNumber, ?bool $absolute = false, ?bool $absoluteRow = null): string
     {
         return Helper::cellAddress($rowNumber, $colNumber, $absolute, $absoluteRow);
     }
@@ -1336,7 +1336,7 @@ class Excel implements InterfaceBookWriter
      *
      * @return Sheet
      */
-    public function makeSheet(string $sheetName = null): Sheet
+    public function makeSheet(?string $sheetName = null): Sheet
     {
         if ($sheetName === null) {
             $sheetName = $this->getDefaultSheetName();
@@ -1767,7 +1767,7 @@ class Excel implements InterfaceBookWriter
      *
      * @param string|null $name
      */
-    public function download(string $name = null)
+    public function download(?string $name = null)
     {
         $tmpFile = $this->writer->makeTempFileName(uniqid('xlsx_writer_'));
         $this->save($tmpFile);

--- a/src/FastExcelWriter/Sheet.php
+++ b/src/FastExcelWriter/Sheet.php
@@ -903,14 +903,14 @@ class Sheet implements InterfaceSheetWriter
     }
 
     /**
-     * @deprecated since v.6.1
-     *
      * @param $arg1
      * @param array|null $arg2
      *
      * @return $this
+     *@deprecated since v.6.1
+     *
      */
-    public function setColStyles($arg1, array $arg2 = null): Sheet
+    public function setColStyles($arg1, ?array $arg2 = null): Sheet
     {
         return $this->setColStyle($arg1, $arg2);
     }
@@ -919,7 +919,7 @@ class Sheet implements InterfaceSheetWriter
      * Use 'setColDataStyle()' or 'setColDataStyleArray()' instead
      * @deprecated since v.6.1
      */
-    public function setColOptions($arg1, array $arg2 = null): Sheet
+    public function setColOptions($arg1, ?array $arg2 = null): Sheet
     {
         if ($arg2 === null) {
             return $this->setColDataStyleArray($arg1);
@@ -1478,7 +1478,7 @@ class Sheet implements InterfaceSheetWriter
      * Use 'setRowDataStyle()' or 'setRowDataStyleArray()' instead
      * @deprecated since v.6.1
      */
-    public function setRowOptions($arg1, array $arg2 = null): Sheet
+    public function setRowOptions($arg1, ?array $arg2 = null): Sheet
     {
         if ($arg2 === null) {
             return $this->setRowDataStyleArray($arg1);
@@ -1488,14 +1488,14 @@ class Sheet implements InterfaceSheetWriter
     }
 
     /**
-     * @deprecated since v.6.1
-     *
      * @param $arg1
      * @param array|null $arg2
      *
      * @return $this
+     *@deprecated since v.6.1
+     *
      */
-    public function setRowStyles($arg1, array $arg2 = null): Sheet
+    public function setRowStyles($arg1, ?array $arg2 = null): Sheet
     {
         return $this->setRowOptions($arg1, $arg2);
     }
@@ -1976,7 +1976,7 @@ class Sheet implements InterfaceSheetWriter
      *
      * @return $this
      */
-    public function writeCell($value, array $styles = null): Sheet
+    public function writeCell($value, ?array $styles = null): Sheet
     {
         $this->_checkOutput();
 
@@ -2010,18 +2010,18 @@ class Sheet implements InterfaceSheetWriter
     }
 
     /**
-     * @example
-     * $sheet->writeHeader(['title1', 'title2', 'title3']); // texts for cells of header
-     * $sheet->writeHeader(['title1' => '@text', 'title2' => 'YYYY-MM-DD', 'title3' => ['format' => ..., 'font' => ...]]); // texts and formats of columns
-     * $sheet->writeHeader($cellValues, $rowStyle, $colStyles); // texts and formats of columns and options of row
-     *
      * @param array $header
      * @param array|null $rowStyle
      * @param array|null $colStyles
      *
      * @return $this
+     *@example
+     * $sheet->writeHeader(['title1', 'title2', 'title3']); // texts for cells of header
+     * $sheet->writeHeader(['title1' => '@text', 'title2' => 'YYYY-MM-DD', 'title3' => ['format' => ..., 'font' => ...]]); // texts and formats of columns
+     * $sheet->writeHeader($cellValues, $rowStyle, $colStyles); // texts and formats of columns and options of row
+     *
      */
-    public function writeHeader(array $header, array $rowStyle = null, ?array $colStyles = []): Sheet
+    public function writeHeader(array $header, ?array $rowStyle = null, ?array $colStyles = []): Sheet
     {
         $rowValues = [];
         $colNum = 0;
@@ -2356,7 +2356,7 @@ class Sheet implements InterfaceSheetWriter
      *
      * @return $this
      */
-    public function writeRow(array $rowValues = [], array $rowStyle = null, array $cellStyles = null): Sheet
+    public function writeRow(array $rowValues = [], ?array $rowStyle = null, ?array $cellStyles = null): Sheet
     {
         $this->_checkOutput();
 
@@ -2418,7 +2418,7 @@ class Sheet implements InterfaceSheetWriter
      *
      * @return $this
      */
-    public function writeArray(array $rowArray = [], array $rowStyle = null): Sheet
+    public function writeArray(array $rowArray = [], ?array $rowStyle = null): Sheet
     {
         foreach ($rowArray as $rowValues) {
             $this->writeRow($rowValues, $rowStyle);
@@ -2511,7 +2511,7 @@ class Sheet implements InterfaceSheetWriter
      *
      * @return Area
      */
-    public function beginArea(string $cellAddress = null): Area
+    public function beginArea(?string $cellAddress = null): Area
     {
         if (null === $cellAddress) {
             $cellAddress = 'A' . ($this->rowCountWritten + 1);
@@ -2767,7 +2767,7 @@ class Sheet implements InterfaceSheetWriter
      *
      * @return $this
      */
-    public function setFormula($cellAddress, $value, array $styles = null): Sheet
+    public function setFormula($cellAddress, $value, ?array $styles = null): Sheet
     {
         if (empty($value)) {
             $value = null;

--- a/src/FastExcelWriter/StyleManager.php
+++ b/src/FastExcelWriter/StyleManager.php
@@ -945,7 +945,7 @@ class StyleManager
      *
      * @return int
      */
-    protected function addElement(string $sectionName, $value, array $fullStyle = null, ?int $replaceIndex = null): int
+    protected function addElement(string $sectionName, $value, ?array $fullStyle = null, ?int $replaceIndex = null): int
     {
         if (is_string($value)) {
             $key = $value;
@@ -1369,7 +1369,7 @@ class StyleManager
      *
      * @return string
      */
-    private static function determineNumberFormatType(string $numFormat, string $format = null): string
+    private static function determineNumberFormatType(string $numFormat, ?string $format = null): string
     {
         if ($format === '@URL') {
             return 'n_shared_string';


### PR DESCRIPTION
This library will throw php 8.4 as of now. This changes fixes those: Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead.
