### PR TITLE
fixed unclosed filehandle

### DIFF
--- a/src/FastExcelWriter/Writer/FileWriter.php
+++ b/src/FastExcelWriter/Writer/FileWriter.php
@@ -271,6 +271,7 @@ class FileWriter
         fclose($fd2);
         $this->fd = $fdTarget;
         $this->fileName = $newFileName;
+        $this->close = false;
 
         return $n1 + $n2;
     }


### PR DESCRIPTION
fixed resetting ->close after overriding filehandle resource

This will result in errors especially when you use custom temp directories and want to remove them before the shutdown handler comes, the file that is still opened cannot be deleted.

Easy fix by resetting the close flag, so it closes automatically again when needed