### PR TITLE
Add functionality to use Header and Footer text for the Printlayout

### DIFF
--- a/docs/02-sheets.md
+++ b/docs/02-sheets.md
@@ -86,6 +86,13 @@ $sheet->pageMarginLeft('0.5mm'); // set left margin 0.5 millimeters
 ```
 
 
+### Print Header and Footer
+
+```php
+// Set the same Header and Footer for all Pages
+$sheet->pageHeaderFooter('Print Header', 'Print Footer');
+```
+
 ### Freeze Panes and Autofilter
 
 ```php

--- a/src/FastExcelWriter/Sheet.php
+++ b/src/FastExcelWriter/Sheet.php
@@ -166,6 +166,8 @@ class Sheet implements InterfaceSheetWriter
 
     // bottom sheet nodes
     protected array $bottomNodesOptions = [];
+    
+    protected array $headerFooter = [];
 
     protected array $printAreas = [];
     protected string $printTopRows = '';
@@ -197,22 +199,6 @@ class Sheet implements InterfaceSheetWriter
                 'verticalDpi' => '0',
                 'orientation' => 'portrait',
             ],
-            /*
-            'headerFooter' => [
-                'differentFirst' => false,
-                'differentOddEven' => false,
-                '__kids' => [
-                    [
-                        '__name' => 'oddHeader',
-                        '__attr' => [],
-                    ],
-                    [
-                        '__name' => 'oddFooter',
-                        '__attr' => [],
-                    ],
-                ],
-            ],
-            */
         ];
 
         $this->sheetViews = [
@@ -5392,6 +5378,24 @@ class Sheet implements InterfaceSheetWriter
     {
 
         return Excel::cellAddress($this->lastTouch['area']['row_idx2'] + 1, $this->lastTouch['area']['col_idx2'] + 1, $absolute);
+    }
+    
+    public function pageHeaderFooter(?string $header, ?string $footer): void
+    {
+        $this->headerFooter = [
+            'differentFirst' => false,
+            'differentOddEven' => false,
+            'oddHeader' => $header,
+            'oddFooter' => $footer
+        ];
+    }
+
+    /**
+     * @return array{differentFirst: bool, differentOddEven: bool, oddHeader: string, oddFooter: string}
+     */
+    public function getHeaderFooterOptions(): array
+    {
+        return $this->headerFooter;
     }
 }
 

--- a/src/FastExcelWriter/Writer/Writer.php
+++ b/src/FastExcelWriter/Writer/Writer.php
@@ -1287,6 +1287,18 @@ class Writer
             $sheet->fileWriter->write($this->_makeTag($nodeName, $nodeOptions));
         }
 
+        $headerFooterOptions = $sheet->getHeaderFooterOptions();
+        if ($headerFooterOptions !== []) {
+            $sheet->fileWriter->write(sprintf(
+                '<headerFooter differentFirst="%s" differentOddEven="%s">', 
+                $headerFooterOptions['differentFirst'] ? 'true' : 'false',
+                $headerFooterOptions['differentOddEven'] ? 'true' : 'false',
+            ));
+            $sheet->fileWriter->write(sprintf('<oddHeader>&amp;C%s</oddHeader>', $headerFooterOptions['oddHeader']));
+            $sheet->fileWriter->write(sprintf('<oddFooter>&amp;C%s</oddFooter>', $headerFooterOptions['oddFooter']));
+            $sheet->fileWriter->write('</headerFooter>');
+        }
+
         $sheet->fileWriter->write('</worksheet>');
         $sheet->fileWriter->flush(true);
 

--- a/tests/FastExcelWriterTest.php
+++ b/tests/FastExcelWriterTest.php
@@ -250,6 +250,7 @@ final class FastExcelWriterTest extends TestCase
         $sheet->setAutofilter();
         $sheet->addNamedRange('b2:c3', 'b2c3');
         $sheet->setPrintArea('a2:f2,a4:f4')->setPrintTitles('1', 'a:b');
+        $sheet->pageHeaderFooter('Header', 'Footer');
 
         $this->excelReader = $this->saveCheckRead($excel, $testFileName);
         $this->cells = $this->excelReader->readRows(false, null, true);


### PR DESCRIPTION
Hey,
i miss the feature to set a Header and Footer line for the Printlayout and created this small PR to implement the basic implementation for this feature.

Note for the `&C`:  This will center the characters that follow.