### PR TITLE
fixed error with mb_strtolower and null result in deprecation error

### DIFF
--- a/src/FastExcelWriter/Excel.php
+++ b/src/FastExcelWriter/Excel.php
@@ -1474,8 +1474,7 @@ class Excel implements InterfaceBookWriter
         if (null === $index) {
             array_shift($this->sheets);
         }
-
-        if (is_int($index)) {
+        elseif (is_int($index)) {
             $keys = array_keys($this->sheets);
             if (!isset($keys[--$index])) {
                 throw  new Exception('Sheet #' . $index . ' not found');


### PR DESCRIPTION
Calling "removeSheet" with a null parameter causes

```
mb_strtolower(): Passing null to parameter #1 ($string) of type string is deprecated
```

This pr fixes is by adding a elseif condition, because "null" check is already handled, but the other checks run also which shouldnt happen in this case