### PR TITLE
fixed $http_response_header php85 error

### DIFF
--- a/src/FastExcelWriter/Excel.php
+++ b/src/FastExcelWriter/Excel.php
@@ -1666,6 +1666,9 @@ class Excel implements InterfaceBookWriter
                     ],
                 ])
             );
+            if (!isset($http_response_header)) {
+                $http_response_header = null;
+            }
             $headers = function_exists('http_get_last_response_headers') ? http_get_last_response_headers() : $http_response_header;
             if (isset($headers[0])) {
                 if (preg_match('#\s404\s#', $headers[0])) {


### PR DESCRIPTION
Another fix for the 

    Deprecated: The predefined locally scoped $http_response_header variable is deprecated, call http_get_last_response_headers()

error. This should work now properly with backward compatibility