### PR TITLE
fix(autoload): replace backslashes with slashes for Linux compatibility

### DIFF
--- a/src/autoload.php
+++ b/src/autoload.php
@@ -3,7 +3,10 @@
 spl_autoload_register(static function ($class) {
     $namespace = 'avadim\\FastExcelWriter\\';
     if (0 === strpos($class, $namespace)) {
-        include __DIR__ . '/FastExcelWriter/' . str_replace($namespace, '', $class) . '.php';
+        $file = str_replace('\\', '/', __DIR__ . '/FastExcelWriter/' . str_replace($namespace, '', $class) . '.php');
+        if (file_exists($file)) {
+            include $file;
+        }
     }
 });
 


### PR DESCRIPTION
The autoloader used Windows-style backslashes when building file paths. This caused "Interface not found" errors on Linux servers where backslashes are invalid path separators. Updated to convert '\\' to '/' before including the file.